### PR TITLE
v0.9.31 - improving ChangeLog

### DIFF
--- a/README-devtools-MDH.mm
+++ b/README-devtools-MDH.mm
@@ -11,7 +11,7 @@
 <font SIZE="24"/>
 <stylenode LOCALIZED_TEXT="styles.predefined" POSITION="right" STYLE="bubble">
 <stylenode LOCALIZED_TEXT="default" ID="ID_271890427" ICON_SIZE="12 pt" FORMAT_AS_HYPERLINK="false" COLOR="#000000" STYLE="fork" NUMBERED="false" FORMAT="STANDARD_FORMAT" TEXT_ALIGN="DEFAULT" MAX_WIDTH="10 cm" MIN_WIDTH="0 cm" VGAP_QUANTITY="2 pt" BORDER_WIDTH_LIKE_EDGE="false" BORDER_WIDTH="1 px" BORDER_COLOR_LIKE_EDGE="true" BORDER_COLOR="#808080" BORDER_DASH_LIKE_EDGE="false" BORDER_DASH="SOLID">
-<arrowlink SHAPE="CUBIC_CURVE" COLOR="#000000" WIDTH="2" TRANSPARENCY="200" DASH="" FONT_SIZE="9" FONT_FAMILY="SansSerif" DESTINATION="ID_271890427" STARTINCLINATION="65.25 pt;-28.5 pt;" ENDINCLINATION="55.5 pt;18.75 pt;" STARTARROW="NONE" ENDARROW="DEFAULT"/>
+<arrowlink SHAPE="CUBIC_CURVE" COLOR="#000000" WIDTH="2" TRANSPARENCY="200" DASH="" FONT_SIZE="9" FONT_FAMILY="SansSerif" DESTINATION="ID_271890427" STARTINCLINATION="65.25 pt;-27.75 pt;" ENDINCLINATION="55.5 pt;18.75 pt;" STARTARROW="NONE" ENDARROW="DEFAULT"/>
 <font NAME="SansSerif" SIZE="10" BOLD="false" STRIKETHROUGH="false" ITALIC="false"/>
 <richcontent CONTENT-TYPE="plain/auto" TYPE="DETAILS"/>
 <richcontent TYPE="NOTE" CONTENT-TYPE="plain/auto"/>
@@ -659,6 +659,7 @@ blockquote {
 <node TEXT="&quot;**Package add-on for publication**&quot; can now open the new add-on for direct installation" ID="ID_250352766"/>
 </node>
 </node>
+</node>
 <node TEXT="New in v0.9.30:" ID="ID_250849647">
 <node TEXT="list" STYLE_REF="MarkdownHelperNode" ID="ID_955469551"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
@@ -678,9 +679,30 @@ blockquote {
 </node>
 </node>
 </node>
+<node TEXT="New in v0.9.31:" ID="ID_1227746329">
+<node TEXT="list" STYLE_REF="MarkdownHelperNode" ID="ID_632094024"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<html>
+  <head>
+    
+  </head>
+  <body>
+    <p>
+      = edofro.MarkDownHelper.MDH.list(node)
+    </p>
+  </body>
+</html></richcontent>
+<node TEXT="**changeLogURL** added as **preference parameter**" ID="ID_585495645"/>
+<node TEXT=" **change log URL** property to **version.properties**" ID="ID_846931039">
+<node TEXT="Now it adds the **changelogurl** property to the **version.properties** file" ID="ID_173510244"/>
+<node TEXT="This way the user can download the **History** file directly from Freeplane&apos;s **check updates** dialog" ID="ID_1124481452"/>
+</node>
+<node TEXT="automatically creates and updates &apos;**history.md**&apos; file" ID="ID_1372738195">
+<node TEXT="&quot;**Package add-on for publication**&quot; automatically creates a &quot;**history.md**&quot; file using the information form the &quot;**changes**&quot; node" ID="ID_1257424063"/>
 </node>
 </node>
-<node TEXT="Change Log" FOLDED="true" ID="ID_309963735">
+</node>
+</node>
+<node TEXT="Change Log" ID="ID_309963735">
 <node TEXT="list" STYLE_REF="MarkdownHelperNode" ID="ID_1015823873"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
@@ -692,7 +714,12 @@ blockquote {
     </p>
   </body>
 </html></richcontent>
-<node TEXT="v0.9.30" ID="ID_1353343071">
+<node TEXT="v0.9.31" ID="ID_1185204241">
+<node TEXT="now it creates and updates &apos;history.md&apos; file" ID="ID_474363164"/>
+<node TEXT="adds changelogurl property to version.properties file" ID="ID_1264034468"/>
+<node TEXT="changeLogURL added as preference parameter" ID="ID_1782400840"/>
+</node>
+<node TEXT="v0.9.30" FOLDED="true" ID="ID_1353343071">
 <node TEXT="bug fixes" ID="ID_455683896"/>
 <node TEXT="Added parametric preferences.xml" ID="ID_1150518564"/>
 </node>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ And its official websites are:
 
 In this fork I united the last version from [HaaiHenkie](https://sourceforge.net/u/haaihenkie/profile/) ([v.0.9.27](https://github.com/HaaiHenkie/addons/tree/fix-bug-2847), look this [thread](https://sourceforge.net/p/freeplane/bugs/2847/)) with the [version](https://github.com/gpapp/freeplane-devtools) from [gpapp](https://sourceforge.net/u/gergelypapp/profile/) .
 
-The instalable file (```devtools-v0.9.30.addon.mm```) of the latest version of the this fork can be downloaded from [here](https://github.com/EdoFro/freeplane-devtools/releases/latest/).
+The instalable file (```devtools-v0.9.31.addon.mm```) of the latest version of the this fork can be downloaded from [here](https://github.com/EdoFro/freeplane-devtools/releases/latest/).
 
 bye,
 
@@ -122,15 +122,28 @@ The functions are available under Tools -> Development Tools
    * It transform a camelCase file name into a normal phrase
 * "**Package add-on for publication**" can now open the new add-on for direct installation
 
-#### 2.3.5. New in v0.9.30:
+### 2.4. New in v0.9.30:
 
 * Now you can add the **preference parameters** as *attributes* in the "preferences.xml" node and it will automatically
    * **build the XML** text as the child node
    * add the preferences to the **properties.default** node, where you can define their default values
    * add the preferences to the **translations** node, where you can define their **Option panel**  *labels* and *tooltips* texts
 
+### 2.5. New in v0.9.31:
+
+* **changeLogURL** added as **preference parameter**
+*  **change log URL** property to **version.properties**
+   * Now it adds the **changelogurl** property to the **version.properties** file
+   * This way the user can download the **History** file directly from Freeplane's **check updates** dialog
+* automatically creates and updates '**history.md**' file
+   * "**Package add-on for publication**" automatically creates a "**history.md**" file using the information form the "**changes**" node
+
 ## 3. Change Log
 
+* v0.9.31
+   * now it creates and updates 'history.md' file
+   * adds changelogurl property to version.properties file
+   * changeLogURL added as preference parameter
 * v0.9.30
    * bug fixes
    * Added parametric preferences.xml

--- a/src/resources/devtools.mm
+++ b/src/resources/devtools.mm
@@ -670,7 +670,7 @@
 </html></richcontent>
 </node>
 </node>
-<node TEXT="changes" FOLDED="true" POSITION="left" ID="ID_309963735"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="changes" POSITION="left" ID="ID_309963735"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -812,6 +812,7 @@
 <node TEXT="Added parametric preferences.xml" ID="ID_1150518564"/>
 </node>
 <node TEXT="v0.9.31" ID="ID_1185204241">
+<node TEXT="changeLogURL added as preference parameter" ID="ID_1782400840"/>
 <node TEXT="now it creates and updates &apos;history.md&apos; file" ID="ID_1372738195"/>
 <node TEXT="adds changelogurl property to version.properties file" ID="ID_846931039"/>
 </node>

--- a/src/resources/devtools.mm
+++ b/src/resources/devtools.mm
@@ -4,14 +4,14 @@
 <font SIZE="16" BOLD="true" ITALIC="true"/>
 <attribute_layout NAME_WIDTH="117 pt" VALUE_WIDTH="291.74999 pt"/>
 <attribute NAME="name" VALUE="devtools"/>
-<attribute NAME="version" VALUE="v0.9.30"/>
+<attribute NAME="version" VALUE="v0.9.31"/>
 <attribute NAME="author" VALUE="Volker Börchers, Henk van den Akker, Gergely Papp, Edo Frohlich"/>
 <attribute NAME="freeplaneVersionFrom" VALUE="v1.8.0"/>
 <attribute NAME="freeplaneVersionTo" VALUE=""/>
-<attribute NAME="updateUrl" VALUE="${homepage}/releases/latest/download/version.properties"/>
 <attribute NAME="addonsMenu" VALUE="main_menu_scripting"/>
 <attribute NAME="downloadUrl" VALUE="${homepage}/releases/download/${version}/"/>
-<attribute NAME="changelogUrl" VALUE=""/>
+<attribute NAME="updateUrl" VALUE="${homepage}/releases/latest/download/version.properties"/>
+<attribute NAME="changelogUrl" VALUE="${homepage}/releases/latest/download/history.md"/>
 <richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
@@ -778,6 +778,10 @@
 <node TEXT="bug fixes" ID="ID_455683896"/>
 <node TEXT="Added parametric preferences.xml" ID="ID_1150518564"/>
 </node>
+<node TEXT="v0.9.31" ID="ID_1185204241">
+<node TEXT="now it creates and updates &apos;history.md&apos; file" ID="ID_1372738195"/>
+<node TEXT="adds changelogurl property to version.properties file" ID="ID_846931039"/>
+</node>
 </node>
 <node TEXT="license" FOLDED="true" POSITION="left" ID="ID_770036552"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
@@ -908,17 +912,20 @@
   </body>
 </html>
 </richcontent>
+<attribute_layout NAME_WIDTH="78.75 pt" VALUE_WIDTH="48 pt"/>
 <attribute NAME="addonsMenu" VALUE="string"/>
 <attribute NAME="updateUrl" VALUE="string"/>
 <attribute NAME="downloadUrl" VALUE="string"/>
-<node TEXT="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#xa;&lt;preferences_structure&gt;&#xa;         &lt;tabbed_pane&gt;&#xa;                  &lt;tab name=&quot;plugins&quot;&gt;&#xa;                            &lt;separator name = &quot;${name}&quot;&gt;&#xa;                                    &lt;string name = &quot;${name}_addonsMenu&quot;/&gt;&#xa;                                    &lt;string name = &quot;${name}_updateUrl&quot;/&gt;&#xa;                                    &lt;string name = &quot;${name}_downloadUrl&quot;/&gt;&#xa;                           &lt;/separator&gt;&#xa;                  &lt;/tab&gt;&#xa;         &lt;/tabbed_pane&gt;&#xa;&lt;/preferences_structure&gt;" ID="ID_695932748" MAX_WIDTH="20 cm"/>
+<attribute NAME="changelogUrl" VALUE="string"/>
+<node TEXT="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#xa;&lt;preferences_structure&gt;&#xa;         &lt;tabbed_pane&gt;&#xa;                  &lt;tab name=&quot;plugins&quot;&gt;&#xa;                            &lt;separator name = &quot;${name}&quot;&gt;&#xa;                                    &lt;string name = &quot;${name}_addonsMenu&quot;/&gt;&#xa;                                    &lt;string name = &quot;${name}_updateUrl&quot;/&gt;&#xa;                                    &lt;string name = &quot;${name}_downloadUrl&quot;/&gt;&#xa;                                    &lt;string name = &quot;${name}_changelogUrl&quot;/&gt;&#xa;                           &lt;/separator&gt;&#xa;                  &lt;/tab&gt;&#xa;         &lt;/tabbed_pane&gt;&#xa;&lt;/preferences_structure&gt;" ID="ID_695932748" MAX_WIDTH="20 cm"/>
 </node>
 <node TEXT="default.properties" POSITION="left" ID="ID_1363888784">
-<attribute_layout NAME_WIDTH="119.25 pt" VALUE_WIDTH="158.25 pt"/>
+<attribute_layout NAME_WIDTH="120.75 pt" VALUE_WIDTH="158.25 pt"/>
 <attribute NAME="${name}.icon" VALUE="/images/${name}-icon.png"/>
 <attribute NAME="${name}_addonsMenu" VALUE="main_menu_scripting"/>
 <attribute NAME="${name}_updateUrl" VALUE="S{homepage}/version.properties"/>
-<attribute NAME="${name}_downloadUrl" VALUE="S{homepage}/"/>
+<attribute NAME="${name}_downloadUrl" VALUE="S{homepage}"/>
+<attribute NAME="${name}_changelogUrl" VALUE="S{homepage}/history.md"/>
 <richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
@@ -977,7 +984,7 @@
 <attribute NAME="addons.${name}.exportTranslations" VALUE="\u00DCbersetzungen exportieren"/>
 </node>
 <node TEXT="en" ID="ID_1080797994">
-<attribute_layout NAME_WIDTH="199.49999 pt" VALUE_WIDTH="912.74997 pt"/>
+<attribute_layout NAME_WIDTH="200.99999 pt" VALUE_WIDTH="910.49997 pt"/>
 <attribute NAME="addons.${name}.menuItemInfo" VALUE="Menu item info"/>
 <attribute NAME="addons.${name}.checkAddOn" VALUE="Build add-on"/>
 <attribute NAME="addons.${name}.importTranslations" VALUE="Import Translations"/>
@@ -988,14 +995,16 @@
 <attribute NAME="addons.${name}.insertBinary" VALUE="Insert Binary"/>
 <attribute NAME="OptionPanel.${name}_addonsMenu.tooltip" VALUE="Defines the addon&apos;s main menu location in Freeplane&apos;s UI, defaults menu &apos;main_menu_scripting&apos;"/>
 <attribute NAME="OptionPanel.separator.${name}" VALUE="Developer Tools"/>
-<attribute NAME="OptionPanel.${name}_downloadUrl.tooltip" VALUE="URL from the place where the AddOn file will be available for downloading. \nBy default is the same as the homepage. \nYou can define a different place or a subfolder of the homepage. \nExample: &quot;${homepage}/files/&quot;"/>
+<attribute NAME="OptionPanel.${name}_downloadUrl.tooltip" VALUE="URL from the place where the AddOn file will be available for downloading. \nBy default is the same as the homepage. \nYou can define a different place or a subfolder of the homepage. \nExample: &quot;${homepage}/files&quot;"/>
 <attribute NAME="OptionPanel.${name}_addonsMenu" VALUE="Add-on&apos;s menu "/>
 <attribute NAME="addons.${name}.addOnDoc" VALUE="Generate add-on documentation"/>
 <attribute NAME="OptionPanel.${name}_updateUrl" VALUE="Update URL"/>
-<attribute NAME="OptionPanel.${name}_updateUrl.tooltip" VALUE="URL of the file containing information (version, download url) on the latest version of this add-on. \nBy default: &quot;${homepage}/version.properties&quot;"/>
+<attribute NAME="OptionPanel.${name}_updateUrl.tooltip" VALUE="URL of the file containing information (version, download url, change log url) on the latest version of this add-on. \nBy default: &quot;${homepage}/version.properties&quot;"/>
 <attribute NAME="addons.${name}.inspectInstalledAddOn" VALUE="Add-on properties info"/>
 <attribute NAME="addons.${name}.extractBinary" VALUE="Extract Binary"/>
 <attribute NAME="addons.${name}.exportTranslations" VALUE="Export Translations"/>
+<attribute NAME="OptionPanel.${name}_changelogUrl" VALUE="Change log URL"/>
+<attribute NAME="OptionPanel.${name}_changelogUrl.tooltip" VALUE="URL of the file containing the history of the changes done to the AddOn in each release. \nBy default: &quot;${homepage}/history.md&quot;\nother example: &quot;${downloadUrl}/history.md&quot;"/>
 </node>
 <node TEXT="es" ID="ID_1654983484">
 <attribute_layout NAME_WIDTH="195.74999 pt" VALUE_WIDTH="190.49999 pt"/>

--- a/src/resources/devtools.mm
+++ b/src/resources/devtools.mm
@@ -1,7 +1,7 @@
 <map version="freeplane 1.9.13">
 <!--To view this file, download free mind mapping software Freeplane from https://www.freeplane.org -->
 <node TEXT="devtools" FOLDED="false" ID="ID_1723255651" LINK="https://github.com/EdoFro/freeplane-devtools" BACKGROUND_COLOR="#97c7dc" VGAP_QUANTITY="2 pt">
-<font SIZE="16" BOLD="true" ITALIC="true"/>
+<font SIZE="16" BOLD="false" ITALIC="true"/>
 <attribute_layout NAME_WIDTH="117 pt" VALUE_WIDTH="291.74999 pt"/>
 <attribute NAME="name" VALUE="devtools"/>
 <attribute NAME="version" VALUE="v0.9.31"/>
@@ -26,28 +26,61 @@
     </p>
     <ul>
       <li>
-        name: The name of the add-on, normally a technically one (no spaces, no special characters except _.-).
+        <b>name</b>: The name of the add-on, normally a technically one (no spaces, no special characters except _.-).
       </li>
       <li>
-        author: Author's name(s) and (optionally) email adresses.
+        <b>author</b>: Author's name(s) and (optionally) email adresses.
       </li>
       <li>
-        version: Since it's difficult to protect numbers like 1.0 from Freeplane's number parser it's advised to prepend a 'v' to the number, e.g. 'v1.0'.
+        <b>version</b>: Since it's difficult to protect numbers like 1.0 from Freeplane's number parser it's advised to prepend a 'v' to the number, e.g. 'v1.0'.
       </li>
       <li>
-        freeplane-version-from: The oldest compatible Freeplane version. The add-on will not be installed if the Freeplane version is too old.
+        <b>freeplane-version-from</b>: The oldest compatible Freeplane version. The add-on will not be installed if the Freeplane version is too old.
       </li>
       <li>
-        freeplane-version-to: Normally empty: The newest compatible Freeplane version. The add-on will not be installed if the Freeplane version is too new.
+        <b>freeplane-version-to</b>: Normally empty: The newest compatible Freeplane version. The add-on will not be installed if the Freeplane version is too new.
       </li>
       <li>
-        updateUrl: URL of the file containing information (version, download url) on the latest version of this add-on. By default: &quot;${homepage}/version.properties&quot;
+        <b>updateUrl</b>: URL of the file containing information (version, download url) on the latest version of this add-on.<br/>By default: &quot;${homepage}/version.properties&quot;<br/>Examples:
+
+        <ul>
+          <li>
+            <b>For GitHub releases</b>: &quot;${homepage}/releases/latest/download/version.properties&quot;
+          </li>
+          <li>
+            <b>For Github in a folder named like the add-on&nbsp;(in the main repository branch)</b>: &quot;${homepage}/raw/main/${name}/version.properties
+          </li>
+          <li>
+            <b>For Github in a folder named like the add-on&nbsp;(in a repository branch named as the add-on version)</b>: &quot;${homepage}/raw/${version}/${name}/version.properties&quot;
+          </li>
+        </ul>
       </li>
       <li>
-        addonsMenu: Defines the addon's main menu location, defaults menu 'main_menu_scripting'.<br/>Use developer tool menuItemInfo to inspect menu location keys.<br/>This attribute is mandatory.<br/>Example: '/menu_bar/myAddons'
+        <b>addonsMenu</b>: Defines the addon's main menu location, defaults menu 'main_menu_scripting'.<br/>Use developer tool menuItemInfo to inspect menu location keys.<br/>This attribute is mandatory.<br/>Example: '/menu_bar/myAddons'
       </li>
       <li>
-        downloadUrl: URL from the place where the AddOn file will be available for downloading.<br/>By default is the same as the homepage.<br/>You can define a different place or a subfolder of the homepage.<br/>Example: &quot;${homepage}/files/&quot;
+        <b>downloadUrl</b>: URL from the place where the AddOn file will be available for downloading.<br/>By default is the same as the homepage.<br/>You can define a different place or a subfolder of the homepage.<br/>Examples:
+
+        <ul>
+          <li>
+            <b>homepage subfolder 'files'</b>: &quot;${homepage}/files/&quot;
+          </li>
+          <li>
+            <b>For GitHub releases (release named as the add-on version)</b>: ${homepage}/releases/download/${version}/
+          </li>
+        </ul>
+      </li>
+      <li>
+        <b>changelogUrl</b>: URL from the place where the history file will be available for downloading.<br/>By default is &quot;${homepage}/history.md&quot;<br/>You can define a different place or a subfolder of the homepage and a different file name and extension if wanted.<br/>Examples:
+
+        <ul>
+          <li>
+            <b>txt file</b>: &quot;${homepage}/history.md&quot;
+          </li>
+          <li>
+            <b>For GitHub releases as Markdown file</b>: &quot;${homepage}/releases/latest/download/history.md&quot;
+          </li>
+        </ul>
       </li>
     </ul>
   </body>
@@ -637,7 +670,7 @@
 </html></richcontent>
 </node>
 </node>
-<node TEXT="changes" POSITION="left" ID="ID_309963735"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="changes" FOLDED="true" POSITION="left" ID="ID_309963735"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -804,7 +837,7 @@
 <attribute_layout VALUE_WIDTH="100 pt"/>
 <node TEXT="This add-on is free software: you can redistribute it and/or modify&#xa;it under the terms of the GNU General Public License as published by&#xa;the Free Software Foundation, either version 2 of the License, or&#xa;(at your option) any later version.&#xa;&#xa;This program is distributed in the hope that it will be useful,&#xa;but WITHOUT ANY WARRANTY; without even the implied warranty of&#xa;MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the&#xa;GNU General Public License for more details." ID="ID_1912443753"/>
 </node>
-<node TEXT="preferences.xml" POSITION="left" ID="ID_95601904"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="preferences.xml" FOLDED="true" POSITION="left" ID="ID_95601904"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -966,12 +999,21 @@
       <li>
         'addons.${name}.&lt;scriptname&gt;' for each script since it will be the menu title.
       </li>
+      <li>
+        'OptionPanel.separator.${name}' for the add-on's name in the preferences panel
+      </li>
+      <li>
+        'OptionPanel.&lt;property&gt;' for the label of the property in the preferences panel
+      </li>
+      <li>
+        'OptionPanel.&lt;property&gt;.tooltip' for the tooltip message for the property in the preferences panel (whwn hovering on it with the mouse)
+      </li>
     </ul>
   </body>
 </html>
 </richcontent>
-<node TEXT="de" ID="ID_996503158">
-<attribute_layout NAME_WIDTH="195.74999 pt" VALUE_WIDTH="179.99999 pt"/>
+<node TEXT="de" ID="ID_1471360379">
+<attribute_layout NAME_WIDTH="178.49999 pt" VALUE_WIDTH="179.99999 pt"/>
 <attribute NAME="addons.${name}.checkAddOn" VALUE="Komplettiere Add-on"/>
 <attribute NAME="addons.${name}.menuItemInfo" VALUE="Men\u00FCeintrag-Details"/>
 <attribute NAME="addons.${name}.importTranslations" VALUE="\u00DCbersetzungen importieren"/>
@@ -983,7 +1025,7 @@
 <attribute NAME="addons.${name}.insertBinary" VALUE="Binärdatei einfügen"/>
 <attribute NAME="addons.${name}.exportTranslations" VALUE="\u00DCbersetzungen exportieren"/>
 </node>
-<node TEXT="en" ID="ID_1080797994">
+<node TEXT="en" ID="ID_274759134">
 <attribute_layout NAME_WIDTH="200.99999 pt" VALUE_WIDTH="910.49997 pt"/>
 <attribute NAME="addons.${name}.menuItemInfo" VALUE="Menu item info"/>
 <attribute NAME="addons.${name}.checkAddOn" VALUE="Build add-on"/>
@@ -994,6 +1036,7 @@
 <attribute NAME="OptionPanel.${name}_downloadUrl" VALUE="Download URL"/>
 <attribute NAME="addons.${name}.insertBinary" VALUE="Insert Binary"/>
 <attribute NAME="OptionPanel.${name}_addonsMenu.tooltip" VALUE="Defines the addon&apos;s main menu location in Freeplane&apos;s UI, defaults menu &apos;main_menu_scripting&apos;"/>
+<attribute NAME="OptionPanel.${name}_changelogUrl" VALUE="Change log URL"/>
 <attribute NAME="OptionPanel.separator.${name}" VALUE="Developer Tools"/>
 <attribute NAME="OptionPanel.${name}_downloadUrl.tooltip" VALUE="URL from the place where the AddOn file will be available for downloading. \nBy default is the same as the homepage. \nYou can define a different place or a subfolder of the homepage. \nExample: &quot;${homepage}/files&quot;"/>
 <attribute NAME="OptionPanel.${name}_addonsMenu" VALUE="Add-on&apos;s menu "/>
@@ -1001,25 +1044,34 @@
 <attribute NAME="OptionPanel.${name}_updateUrl" VALUE="Update URL"/>
 <attribute NAME="OptionPanel.${name}_updateUrl.tooltip" VALUE="URL of the file containing information (version, download url, change log url) on the latest version of this add-on. \nBy default: &quot;${homepage}/version.properties&quot;"/>
 <attribute NAME="addons.${name}.inspectInstalledAddOn" VALUE="Add-on properties info"/>
+<attribute NAME="OptionPanel.${name}_changelogUrl.tooltip" VALUE="URL of the file containing the history of the changes done to the AddOn in each release. \nBy default: &quot;${homepage}/history.md&quot;\nother example: &quot;${downloadUrl}/history.md&quot;"/>
 <attribute NAME="addons.${name}.extractBinary" VALUE="Extract Binary"/>
 <attribute NAME="addons.${name}.exportTranslations" VALUE="Export Translations"/>
-<attribute NAME="OptionPanel.${name}_changelogUrl" VALUE="Change log URL"/>
-<attribute NAME="OptionPanel.${name}_changelogUrl.tooltip" VALUE="URL of the file containing the history of the changes done to the AddOn in each release. \nBy default: &quot;${homepage}/history.md&quot;\nother example: &quot;${downloadUrl}/history.md&quot;"/>
 </node>
-<node TEXT="es" ID="ID_1654983484">
-<attribute_layout NAME_WIDTH="195.74999 pt" VALUE_WIDTH="190.49999 pt"/>
-<attribute NAME="addons.${name}.checkAddOn" VALUE="Construir add-on"/>
+<node TEXT="es" ID="ID_1662866589">
+<attribute_layout NAME_WIDTH="200.99999 pt" VALUE_WIDTH="840.74997 pt"/>
 <attribute NAME="addons.${name}.menuItemInfo" VALUE="Información de ítem de menú"/>
+<attribute NAME="addons.${name}.checkAddOn" VALUE="Construir add-on"/>
 <attribute NAME="addons.${name}.importTranslations" VALUE="Importar traducciones"/>
 <attribute NAME="addons.${name}.encodeTranslations" VALUE="Codificar traducciones"/>
 <attribute NAME="addons.${name}.releaseAddOn" VALUE="Empaquetar add-on para su publicación"/>
-<attribute NAME="addons.${name}.addOnDoc" VALUE="Generar documentación de add-on"/>
 <attribute NAME="addons.${name}" VALUE="Herramientas para desarrolladores"/>
-<attribute NAME="addons.${name}.extractBinary" VALUE="Extraer binario"/>
+<attribute NAME="OptionPanel.${name}_downloadUrl" VALUE="URL de descarga"/>
 <attribute NAME="addons.${name}.insertBinary" VALUE="Insertar binario"/>
+<attribute NAME="OptionPanel.${name}_addonsMenu.tooltip" VALUE="Define la ubicación del submenú del add-on dentro del menú de Freeplane. &#xa;Valor default: &apos;main_menu_scripting&apos;"/>
+<attribute NAME="OptionPanel.${name}_changelogUrl" VALUE="URL del documento historial de cambios"/>
+<attribute NAME="OptionPanel.separator.${name}" VALUE="Herramientas para desarrolladores"/>
+<attribute NAME="OptionPanel.${name}_downloadUrl.tooltip" VALUE="URL del sitio donde se podrá descargar el add-on. \Por default es el mismo que su homepage. \nSe puede definir un sitio diferente o una subcarpeta de la homepage. \nEjemplo: &quot;${homepage}/files&quot;"/>
+<attribute NAME="OptionPanel.${name}_addonsMenu" VALUE="Menu del Add-on"/>
+<attribute NAME="addons.${name}.addOnDoc" VALUE="Generar documentación de add-on"/>
+<attribute NAME="OptionPanel.${name}_updateUrl" VALUE="URL de actualización"/>
+<attribute NAME="OptionPanel.${name}_updateUrl.tooltip" VALUE="URL del archivo que contiene la información de la última versión del Add-on (versión, URL de descarga, URL del historial).\nPor default: &quot;${homepage}/version.properties&quot;"/>
+<attribute NAME="addons.${name}.inspectInstalledAddOn" VALUE="Obtener inforrmacion de Add-On instalado"/>
+<attribute NAME="OptionPanel.${name}_changelogUrl.tooltip" VALUE="URL para el archivo de Historial de Cambios del Add-on. \nPor default: &quot;${homepage}/history.md&quot;\notro ejemplo: &quot;${downloadUrl}/history.md&quot;"/>
+<attribute NAME="addons.${name}.extractBinary" VALUE="Extraer binario"/>
 <attribute NAME="addons.${name}.exportTranslations" VALUE="Exportar traducciones"/>
 </node>
-<node TEXT="nl" ID="ID_1255099843">
+<node TEXT="nl" ID="ID_480131137">
 <attribute_layout NAME_WIDTH="178.49999 pt" VALUE_WIDTH="157.5 pt"/>
 <attribute NAME="addons.${name}.checkAddOn" VALUE="Add-on opbouwen"/>
 <attribute NAME="addons.${name}.menuItemInfo" VALUE="Menu item info"/>

--- a/src/resources/history.md
+++ b/src/resources/history.md
@@ -2,6 +2,7 @@
 
 ## v0.9.31
 
+* changeLogURL added as preference parameter
 * now it creates and updates 'history.md' file
 * adds changelogurl property to version.properties file
 

--- a/src/resources/history.md
+++ b/src/resources/history.md
@@ -1,0 +1,149 @@
+# History
+
+## v0.9.31
+
+* now it creates and updates 'history.md' file
+* adds changelogurl property to version.properties file
+
+## v0.9.30
+
+* bug fixes
+* Added parametric preferences.xml
+
+## v0.9.29
+
+* Added inspectInstalledAddOn
+* Added "Export Translations" and "Import Translations" to "actions" node
+* Now it proposes a menu text for the new scripts based on its file name
+* It deletes the 'actions' node in the add-on package
+* "Export Translations" creates 'translations' folder if it doesn't exist
+* releaseAddOn now can install the add-on directly
+
+## v0.9.28
+
+* Merged with GPAPP devtools version
+* added improved downloadUrl
+* Improved updateUrl
+* Added addonsMenu
+* Added "actions" node with links to Build and Package commands
+* Added script "exportTranslation"
+* Added script "importTranslation"
+* Added spanish translation
+
+## v0.9.27
+
+* #2847 Devtools' checkAddOn.groovy not compatible with Gradle plugin's directory structure
+
+## v0.9.26
+
+* Fix for #2798 : Menu Item Info error
+
+## v0.9.25
+
+* #2643 Devtools does not display its add-on name in menu
+* #2464 test for missing English translations for scripts
+* Set icon for devtools sub menu
+
+## v0.9.24
+
+* Fix for #2386 Special characters in add-on translations wrongly displayed
+* #2642 Devtools creates wrong menuTitleKey for scripts
+
+## v0.9.23
+
+* Fix for Freeplane 1.7.x
+
+## v0.9.22
+
+* added extractBinary
+
+## v0.9.21
+
+* menuItemInfo: adjusted to Freeplane 1.4 while keeping compatibility to 1.3
+* releaseAddOn: avoid problems with paths containing spaces
+* checkAddOn: add check for the add-on homepage
+* encodeTranslations: fix menu location
+
+## v0.9.20
+
+* fix path to version.properties
+* #2234 dealing with spaces in filenames leads releaseAddOn.groovy to crash
+
+## v0.9.19
+
+* added Dutch translation - thanks to Haai Henkie!
+* checkAddOn.groovy: ignore classpath, .project and freeplane.dsld from scripts/
+
+## v0.9.18
+
+* Fix bug in checkAddOn.groovy that prevented uninstall node from being updated.
+
+## v0.9.17
+
+* fix translation encoding
+
+## v0.9.16
+
+* Fix Package add-on (Mantis #2106):
+- no recursive searches for required nodes
+- avoid out of memory exception on errors
+
+## v0.9.15
+
+* adjusted to new scripts location in Freeplane 1.3.x_beta
+* update check and release scripts for installation of libs
+* checkAddOn.groovy does a lot more checks and automation than before
+
+## v0.9.14
+
+* update for multiple scripting languages
+* support for updateUrl
+
+## v0.9.13
+
+* update for new special translation key 'addons.${name}.description'
+* checkAddOn.groovy checks the name of the script too
+
+## v0.9.12
+
+* menuItem.groovy: copy string to clipboard
+
+## v0.9.11
+
+* New: menuItemInfo.groovy
+* fixes for 1.2.12
+
+## v0.9.10
+
+* New: addOnDoc.groovy
+* releaseAddOn.groovy:
+Creates the release map as model-only to cope with the map open hook that asks if the map should be installed.
+The map is actually saved at the end.
+* new Icons from Predrag Cuklin
+
+## v0.9.9
+
+* Better error messages in case of missing scripts and zips to include.
+Only look for scripts below the scripts node.
+
+## v0.9.7
+
+* Add support for images.
+Include icon and screenshot.
+
+## v0.9.6
+
+* Add missing file/write permission for insertBinary.groovy
+
+## v0.9.5
+
+* Make checkAddOn.groovy work for maps that are not saved
+
+## v0.9.4
+
+* Adjusted to new add-on format
+* checkAddon.groovy: add script attributes and deinstallation rules; check case of add-on name
+
+## v0.9
+
+* Initial version

--- a/src/resources/scripts/checkAddOn.groovy
+++ b/src/resources/scripts/checkAddOn.groovy
@@ -182,47 +182,89 @@ root.note = withBody '''
       The homepage of this add-on should be set as the link of the root node.
     </p>
     <p>
-      The basic properties of this add-on. They can be used in script names
-      and other attributes, e.g. "${name}.groovy".
+      The basic properties of this add-on. They can be used in script names 
+      and other attributes, e.g. &quot;${name}.groovy&quot;.
     </p>
     <ul>
       <li>
-        name: The name of the add-on, normally a technically one (no spaces,
-        no special characters except _.-).
+        <b>name</b>: The name of the add-on, normally a technically one (no 
+        spaces, no special characters except _.-).
       </li>
       <li>
-        author: Author's name(s) and (optionally) email adresses.
+        <b>author</b>: Author's name(s) and (optionally) email adresses.
       </li>
       <li>
-        version: Since it's difficult to protect numbers like 1.0 from
-        Freeplane's number parser it's advised to prepend a 'v' to the number,
+        <b>version</b>: Since it's difficult to protect numbers like 1.0 from 
+        Freeplane's number parser it's advised to prepend a 'v' to the number, 
         e.g. 'v1.0'.
       </li>
       <li>
-        freeplane-version-from: The oldest compatible Freeplane version. The
-        add-on will not be installed if the Freeplane version is too old.
+        <b>freeplane-version-from</b>: The oldest compatible Freeplane version. 
+        The add-on will not be installed if the Freeplane version is too old.
       </li>
       <li>
-        freeplane-version-to: Normally empty: The newest compatible Freeplane
-        version. The add-on will not be installed if the Freeplane version is
-        too new.
+        <b>freeplane-version-to</b>: Normally empty: The newest compatible 
+        Freeplane version. The add-on will not be installed if the Freeplane 
+        version is too new.
       </li>
       <li>
-        updateUrl: URL of the file containing information (version, download 
-        url) on the latest version of this add-on. By default: 
-        &quot;${homepage}/version.properties&quot;
+        <b>updateUrl</b>: URL of the file containing information (version, 
+        download url) on the latest version of this add-on.<br>By default: 
+        &quot;${homepage}/version.properties&quot;<br>Examples:
+
+        <ul>
+          <li>
+            <b>For GitHub releases</b>: 
+            &quot;${homepage}/releases/latest/download/version.properties&quot;
+          </li>
+          <li>
+            <b>For Github in a folder named like the add-on&nbsp;(in the main 
+            repository branch)</b>: 
+            &quot;${homepage}/raw/main/${name}/version.properties
+          </li>
+          <li>
+            <b>For Github in a folder named like the add-on&nbsp;(in a repository 
+            branch named as the add-on version)</b>: 
+            &quot;${homepage}/raw/${version}/${name}/version.properties&quot;
+          </li>
+        </ul>
       </li>
       <li>
-        addonsMenu: Defines the addon's main menu location, defaults menu 
+        <b>addonsMenu</b>: Defines the addon's main menu location, defaults menu 
         'main_menu_scripting'.<br>Use developer tool menuItemInfo to inspect 
         menu location keys.<br>This attribute is mandatory.<br>Example: 
         '/menu_bar/myAddons'
       </li>
       <li>
-        downloadUrl: URL from the place where the AddOn file will be available 
-        for downloading.<br>By default is the same as the homepage.<br>You can 
-        define a different place or a subfolder of the homepage.<br>Example: 
-        &quot;${homepage}/files/&quot;
+        <b>downloadUrl</b>: URL from the place where the AddOn file will be 
+        available for downloading.<br>By default is the same as the homepage.<br>You 
+        can define a different place or a subfolder of the homepage.<br>Examples:
+
+        <ul>
+          <li>
+            <b>homepage subfolder 'files'</b>: &quot;${homepage}/files/&quot;
+          </li>
+          <li>
+            <b>For GitHub releases (release named as the add-on version)</b>: 
+            ${homepage}/releases/download/${version}/
+          </li>
+        </ul>
+      </li>
+      <li>
+        <b>changelogUrl</b>: URL from the place where the history file will be 
+        available for downloading.<br>By default is &quot;${homepage}/history.md&quot;<br>You 
+        can define a different place or a subfolder of the homepage and a 
+        different file name and extension if wanted.<br>Examples:
+
+        <ul>
+          <li>
+            <b>txt file</b>: &quot;${homepage}/history.md&quot;
+          </li>
+          <li>
+            <b>For GitHub releases as Markdown file</b>: 
+            &quot;${homepage}/releases/latest/download/history.md&quot;
+          </li>
+        </ul>
       </li>
     </ul>
   </body>
@@ -455,17 +497,33 @@ if( checkPreferences && preferencesNode.attributes ){
 def translationsNode = findOrCreate(root, 'translations', LEFT)
 translationsNode.note = withBody '''
     <p>
-      The translation keys that this script uses. Define one child node per supported locale. The attributes contain the translations. Define at least
+      The translation keys that this script uses. Define one child node per 
+      supported locale. The attributes contain the translations. Define at 
+      least
     </p>
     <ul>
       <li>
         'addons.${name}' for the add-on's name
       </li>
       <li>
-        'addons.${name}.description' for the description, e.g. in the add-on overview dialog (not necessary for English)
+        'addons.${name}.description' for the description, e.g. in the add-on 
+        overview dialog (not necessary for English)
       </li>
       <li>
-        'addons.${name}.&lt;scriptname&gt;' for each script since it will be the menu title.
+        'addons.${name}.&lt;scriptname&gt;' for each script since it will be the 
+        menu title.
+      </li>
+      <li>
+        'OptionPanel.separator.${name}' for the add-on's name in the 
+        preferences panel
+      </li>
+      <li>
+        'OptionPanel.&lt;property&gt;' for the label of the property in the 
+        preferences panel
+      </li>
+      <li>
+        'OptionPanel.&lt;property&gt;.tooltip' for the tooltip message for the 
+        property in the preferences panel (whwn hovering on it with the mouse)
       </li>
     </ul>
 '''

--- a/src/resources/scripts/checkAddOn.groovy
+++ b/src/resources/scripts/checkAddOn.groovy
@@ -236,10 +236,10 @@ createMissingAttributes(root, [
     'author',
     'freeplaneVersionFrom',
     'freeplaneVersionTo',
-    ['updateUrl'   ,  config.getProperty('devtools_updateUrl'  , '${homepage}/version.properties' ).replace('S{','${') ],
-    ['downloadUrl' ,  config.getProperty('devtools_downloadUrl', '${homepage}/'                   ).replace('S{','${') ],
-    'changelogUrl' ,
-    ['addonsMenu'  ,  config.getProperty('devtools_addonsMenu' , 'main_menu_scripting'            ).replace('S{','${') ]
+    ['updateUrl'   ,  config.getProperty('devtools_updateUrl'   , '${homepage}/version.properties' ).replace('S{','${') ],
+    ['downloadUrl' ,  config.getProperty('devtools_downloadUrl' , '${homepage}/'                   ).replace('S{','${') ],
+    ['changelogUrl',  config.getProperty('devtools_changelogUrl', '${homepage}/history.txt'        ).replace('S{','${') ],
+    ['addonsMenu'  ,  config.getProperty('devtools_addonsMenu'  , 'main_menu_scripting'            ).replace('S{','${') ]
 ])
 
 

--- a/src/resources/scripts/releaseAddOn.groovy
+++ b/src/resources/scripts/releaseAddOn.groovy
@@ -376,7 +376,9 @@ with ${counts.scripts} script(s), ${counts.images} images(s), ${counts.zips} zip
             counts.translations
         } translations.
 
-Also created: 'version.properties' - upload this file to the configured updateUrl!
+Also created: 
+    'version.properties' - upload this file to the configured updateUrl!
+    'history.md'         - upload this file to the configured changelogUrl!
 
 Open the new add-on map ${releaseMapFile.name}?"""
         final int selection = JOptionPane.showConfirmDialog(ui.frame, question, dialogTitle, JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE)

--- a/src/resources/scripts/releaseAddOn.groovy
+++ b/src/resources/scripts/releaseAddOn.groovy
@@ -37,8 +37,11 @@ dialogTitle = 'Create release package'
 
 def expand(Proxy.Node attributeNode, String string) {
     // expands strings like "${name}.groovy"
-    string.replaceAll(/\$\{([^}]+)\}/, { match, key -> def v = attributeNode.attributes.map[key]; v ? v : match })
-          .replaceAll(/\$\{([^}]+)\}/, { match, key -> key == 'homepage' ? attributeNode.link.text?: match : match })
+    def tempString = string
+    3.times{
+        tempString = tempString.replaceAll(/\$\{([^}]+)\}/, { match, key -> def v = attributeNode.attributes.map[key]; v ? ( v[-1]=='/' ? v.dropRight(1):v ) : match })
+        }
+    return tempString.replaceAll(/\$\{([^}]+)\}/, { match, key -> key == 'homepage' ? attributeNode.link.text?: match : match })
 }
 
 // returns the count of scripts added
@@ -251,14 +254,33 @@ private createLatestVersionFile(Proxy.Node releaseMapRoot) {
     def freeplaneVersionFrom = releaseMapRoot['freeplaneVersionFrom']
     def homepage = toUrl(releaseMapRoot, releaseMapRoot.link.text)
     def downloadPage = toUrl(releaseMapRoot, releaseMapRoot['downloadUrl'].toString()) ?: homepage
+    
     def releaseMapFileName = new File(mapFile.path.replaceFirst("(\\.addon)?\\.mm", "") + "-${version}.addon.mm").name
     def downloadFile = new File(downloadPage.path, releaseMapFileName)
     def downloadFilePath = downloadFile.path.replace(File.separator, '/')
     def downloadUrl  = new URL(downloadPage.protocol, downloadPage.host, downloadPage.port, downloadFilePath)
+
+    def changelogUrl = toUrl(releaseMapRoot, releaseMapRoot['changelogUrl'].toString()) ?: (homepage.toString() + '/history.txt')
+    //def changelogUrl  = new URL(changelogPage.protocol, changelogPage.host, changelogPage.port, changelogPage )
     file.text = """version=${version}
 downloadUrl=${downloadUrl}
+changelogUrl=${changelogUrl}
 freeplaneVersionFrom=${freeplaneVersionFrom}
 """
+}
+
+private createLatestHistoryFile(Proxy.Node releaseMapRoot) {
+    def mapFile = releaseMapRoot.map.file
+    Proxy.Node changesNode = releaseMapRoot.children.find { it.plainText.matches('changes') }
+    def texto = new StringBuilder("# History\n")
+    changesNode.children.reverse().each{ v ->
+        texto << "\n" << "## ${v.text}"  << "\n\n" 
+        v.children.each{ n ->
+            texto << "* ${n.text}"  << "\n"
+        }
+    }
+    def file = new File(mapFile.parent,  "history.md")
+    file.setText(texto.toString(), 'UTF-8')
 }
 
 private URL toUrl(Proxy.Node root, String urlString) {
@@ -334,6 +356,7 @@ try {
     releaseMapRoot['updateUrl'] = toUrl(releaseMapRoot, releaseMapRoot['updateUrl'].toString()) ?: releaseMapRoot['updateUrl']
     releaseMapRoot.children.find{it.plainText == 'actions'}?.delete()
     updatePreferencesXml(releaseMapRoot)
+    createLatestHistoryFile(releaseMapRoot)
 } catch (Exception e) {
     errors << e.message
     e.printStackTrace()

--- a/src/resources/translations/de.properties
+++ b/src/resources/translations/de.properties
@@ -1,4 +1,4 @@
-#Thu Feb 17 18:18:49 CLST 2022
+#Mon Mar 07 13:22:41 CLST 2022
 addons.${name}.checkAddOn=Komplettiere Add-on
 addons.${name}.menuItemInfo=Men\\u00FCeintrag-Details
 addons.${name}.importTranslations=\\u00DCbersetzungen importieren

--- a/src/resources/translations/de.properties
+++ b/src/resources/translations/de.properties
@@ -1,4 +1,4 @@
-#Mon Mar 07 13:22:41 CLST 2022
+#Mon Mar 07 16:45:59 CLST 2022
 addons.${name}.checkAddOn=Komplettiere Add-on
 addons.${name}.menuItemInfo=Men\\u00FCeintrag-Details
 addons.${name}.importTranslations=\\u00DCbersetzungen importieren

--- a/src/resources/translations/en.properties
+++ b/src/resources/translations/en.properties
@@ -1,4 +1,4 @@
-#Mon Mar 07 13:22:41 CLST 2022
+#Mon Mar 07 16:45:59 CLST 2022
 addons.${name}.checkAddOn=Build add-on
 addons.${name}.menuItemInfo=Menu item info
 addons.${name}.importTranslations=Import Translations
@@ -10,12 +10,12 @@ addons.${name}.insertBinary=Insert Binary
 OptionPanel.${name}_addonsMenu.tooltip=Defines the addon's main menu location in Freeplane's UI, defaults menu 'main_menu_scripting'
 OptionPanel.${name}_changelogUrl=Change log URL
 OptionPanel.separator.${name}=Developer Tools
-OptionPanel.${name}_downloadUrl.tooltip=URL from the place where the AddOn file will be available for downloading. \\nBy default is the same as the homepage. \\nYou can define a different place or a subfolder of the homepage. \\nExample\: "${homepage}/files/"
+OptionPanel.${name}_downloadUrl.tooltip=URL from the place where the AddOn file will be available for downloading. \\nBy default is the same as the homepage. \\nYou can define a different place or a subfolder of the homepage. \\nExample\: "${homepage}/files"
 OptionPanel.${name}_addonsMenu=Add-on's menu 
 addons.${name}.addOnDoc=Generate add-on documentation
 OptionPanel.${name}_updateUrl=Update URL
 OptionPanel.${name}_updateUrl.tooltip=URL of the file containing information (version, download url, change log url) on the latest version of this add-on. \\nBy default\: "${homepage}/version.properties"
 addons.${name}.inspectInstalledAddOn=Add-on properties info
-OptionPanel.${name}_changelogUrl.tooltip=URL of the file containing the history of the changes done to the AddOn in each release. \\nBy default\: "${homepage}/history.md"\\nother example\: "${downloadUrl}history.md"
+OptionPanel.${name}_changelogUrl.tooltip=URL of the file containing the history of the changes done to the AddOn in each release. \\nBy default\: "${homepage}/history.md"\\nother example\: "${downloadUrl}/history.md"
 addons.${name}.extractBinary=Extract Binary
 addons.${name}.exportTranslations=Export Translations

--- a/src/resources/translations/en.properties
+++ b/src/resources/translations/en.properties
@@ -1,4 +1,4 @@
-#Thu Feb 17 18:18:49 CLST 2022
+#Mon Mar 07 13:22:41 CLST 2022
 addons.${name}.checkAddOn=Build add-on
 addons.${name}.menuItemInfo=Menu item info
 addons.${name}.importTranslations=Import Translations
@@ -8,12 +8,14 @@ addons.${name}=Developer Tools
 OptionPanel.${name}_downloadUrl=Download URL
 addons.${name}.insertBinary=Insert Binary
 OptionPanel.${name}_addonsMenu.tooltip=Defines the addon's main menu location in Freeplane's UI, defaults menu 'main_menu_scripting'
+OptionPanel.${name}_changelogUrl=Change log URL
 OptionPanel.separator.${name}=Developer Tools
 OptionPanel.${name}_downloadUrl.tooltip=URL from the place where the AddOn file will be available for downloading. \\nBy default is the same as the homepage. \\nYou can define a different place or a subfolder of the homepage. \\nExample\: "${homepage}/files/"
 OptionPanel.${name}_addonsMenu=Add-on's menu 
 addons.${name}.addOnDoc=Generate add-on documentation
 OptionPanel.${name}_updateUrl=Update URL
-OptionPanel.${name}_updateUrl.tooltip=URL of the file containing information (version, download url) on the latest version of this add-on. \\nBy default\: "${homepage}/version.properties"
+OptionPanel.${name}_updateUrl.tooltip=URL of the file containing information (version, download url, change log url) on the latest version of this add-on. \\nBy default\: "${homepage}/version.properties"
 addons.${name}.inspectInstalledAddOn=Add-on properties info
+OptionPanel.${name}_changelogUrl.tooltip=URL of the file containing the history of the changes done to the AddOn in each release. \\nBy default\: "${homepage}/history.md"\\nother example\: "${downloadUrl}history.md"
 addons.${name}.extractBinary=Extract Binary
 addons.${name}.exportTranslations=Export Translations

--- a/src/resources/translations/es.properties
+++ b/src/resources/translations/es.properties
@@ -1,11 +1,21 @@
-#Mon Mar 07 13:22:41 CLST 2022
+#Mon Mar 07 16:45:59 CLST 2022
 addons.${name}.checkAddOn=Construir add-on
 addons.${name}.menuItemInfo=Información de ítem de menú
 addons.${name}.importTranslations=Importar traducciones
 addons.${name}.encodeTranslations=Codificar traducciones
 addons.${name}.releaseAddOn=Empaquetar add-on para su publicación
-addons.${name}.addOnDoc=Generar documentación de add-on
 addons.${name}=Herramientas para desarrolladores
-addons.${name}.extractBinary=Extraer binario
+OptionPanel.${name}_downloadUrl=URL de descarga
 addons.${name}.insertBinary=Insertar binario
+OptionPanel.${name}_addonsMenu.tooltip=Define la ubicación del submenú del add-on dentro del menú de Freeplane. \nValor default\: 'main_menu_scripting'
+OptionPanel.${name}_changelogUrl=URL del documento historial de cambios
+OptionPanel.separator.${name}=Herramientas para desarrolladores
+OptionPanel.${name}_downloadUrl.tooltip=URL del sitio donde se podrá descargar el add-on. \\Por default es el mismo que su homepage. \\nSe puede definir un sitio diferente o una subcarpeta de la homepage. \\nEjemplo\: "${homepage}/files"
+OptionPanel.${name}_addonsMenu=Menu del Add-on
+addons.${name}.addOnDoc=Generar documentación de add-on
+OptionPanel.${name}_updateUrl=URL de actualización
+OptionPanel.${name}_updateUrl.tooltip=URL del archivo que contiene la información de la última versión del Add-on (versión, URL de descarga, URL del historial).\\nPor default\: "${homepage}/version.properties"
+addons.${name}.inspectInstalledAddOn=Obtener inforrmacion de Add-On instalado
+OptionPanel.${name}_changelogUrl.tooltip=URL para el archivo de Historial de Cambios del Add-on. \\nPor default\: "${homepage}/history.md"\\notro ejemplo\: "${downloadUrl}/history.md"
+addons.${name}.extractBinary=Extraer binario
 addons.${name}.exportTranslations=Exportar traducciones

--- a/src/resources/translations/es.properties
+++ b/src/resources/translations/es.properties
@@ -1,4 +1,4 @@
-#Thu Feb 17 18:18:49 CLST 2022
+#Mon Mar 07 13:22:41 CLST 2022
 addons.${name}.checkAddOn=Construir add-on
 addons.${name}.menuItemInfo=Información de ítem de menú
 addons.${name}.importTranslations=Importar traducciones

--- a/src/resources/translations/nl.properties
+++ b/src/resources/translations/nl.properties
@@ -1,4 +1,4 @@
-#Thu Feb 17 18:18:49 CLST 2022
+#Mon Mar 07 13:22:41 CLST 2022
 addons.${name}.checkAddOn=Add-on opbouwen
 addons.${name}.menuItemInfo=Menu item info
 addons.${name}.encodeTranslations=Vertalingen coderen

--- a/src/resources/translations/nl.properties
+++ b/src/resources/translations/nl.properties
@@ -1,4 +1,4 @@
-#Mon Mar 07 13:22:41 CLST 2022
+#Mon Mar 07 16:45:59 CLST 2022
 addons.${name}.checkAddOn=Add-on opbouwen
 addons.${name}.menuItemInfo=Menu item info
 addons.${name}.encodeTranslations=Vertalingen coderen


### PR DESCRIPTION
New in v0.9.31:

* **changeLogURL** added as **preference parameter**
*  **change log URL** property to **version.properties**
   * Now it adds the **changelogurl** property to the **version.properties** file
   * This way the user can download the **History** file directly from Freeplane's **check updates** dialog
* automatically creates and updates '**history.md**' file
   * "**Package add-on for publication**" automatically creates a "**history.md**" file using the information form the "**changes**" node

greetings,

edo